### PR TITLE
Fixed rendering of js handlebars templates in watch tasks

### DIFF
--- a/gulp-tasks/watch.js
+++ b/gulp-tasks/watch.js
@@ -11,11 +11,11 @@ function watchCss () {
 }
 
 function watchJs () {
-  return _gulp.watch(`${_js.paths.srcDir}**/*.js`, [_js.tasks.dev]);
+  return _gulp.watch([`${_js.paths.srcDir}**/*.js`, `${_markup.paths.srcDir}**/*.hbs`], [_js.tasks.dev]);
 }
 
 function watchMarkup () {
-  return _gulp.watch([`${_markup.paths.srcDir}**/*.html`, `${_markup.paths.srcDir}**/*.hbs`], [_markup.tasks.dev]);
+  return _gulp.watch(`${_markup.paths.srcDir}**/*.html`, [_markup.tasks.dev]);
 }
 
 _gulp.task('watch', () => {


### PR DESCRIPTION
It wasn't rendering hbs templates until restarting server. Fixed by adding hbs in watchJs. 